### PR TITLE
Load all controller configs into param server regardless of control mode

### DIFF
--- a/dx_launch/launch/controllers/actuator_effort_controller.launch
+++ b/dx_launch/launch/controllers/actuator_effort_controller.launch
@@ -4,9 +4,7 @@
  Unauthorized copying of the content in this file, via any medium is strictly prohibited.
 -->
 <launch>
-<arg name="hand_type"/>
 <arg name="output" default="screen"/>
-<arg name="side"/>
 
 <node name="spawn_actuator_effort_controller"
       pkg="controller_manager" type="spawner" respawn="false"

--- a/dx_launch/launch/controllers/actuator_pwm_controller.launch
+++ b/dx_launch/launch/controllers/actuator_pwm_controller.launch
@@ -4,9 +4,7 @@
  Unauthorized copying of the content in this file, via any medium is strictly prohibited.
 -->
 <launch>
-<arg name="hand_type"/>
 <arg name="output" default="screen"/>
-<arg name="side"/>
 
 <node name="spawn_actuator_pwm_controller"
       pkg="controller_manager" type="spawner" respawn="false"

--- a/dx_launch/launch/controllers/joint_effort_controller.launch
+++ b/dx_launch/launch/controllers/joint_effort_controller.launch
@@ -4,9 +4,7 @@
  Unauthorized copying of the content in this file, via any medium is strictly prohibited.
 -->
 <launch>
-<arg name="hand_type"/>
 <arg name="output" default="screen"/>
-<arg name="side"/>
 
 <node name="joint_effort_controller"
       pkg="controller_manager" type="spawner" respawn="false"

--- a/dx_launch/launch/controllers/position_controller.launch
+++ b/dx_launch/launch/controllers/position_controller.launch
@@ -4,9 +4,7 @@
  Unauthorized copying of the content in this file, via any medium is strictly prohibited.
 -->
 <launch>
-<arg name="hand_type"/>
 <arg name="output" default="screen"/>
-<arg name="side"/>
 
 <node name="spawn_position_controller"
       pkg="controller_manager" type="spawner" respawn="false"

--- a/dx_launch/launch/controllers/trajectory_controller.launch
+++ b/dx_launch/launch/controllers/trajectory_controller.launch
@@ -4,9 +4,7 @@
  Unauthorized copying of the content in this file, via any medium is strictly prohibited.
 -->
 <launch>
-<arg name="hand_type"/>
 <arg name="output" default="screen"/>
-<arg name="side"/>
 
 <node name="spawn_trajectory_controller"
       pkg="controller_manager" type="spawner" respawn="false"

--- a/dx_launch/launch/dexee_real.launch.xml
+++ b/dx_launch/launch/dexee_real.launch.xml
@@ -45,7 +45,7 @@
   <rosparam command="load" file="$(find dx_config)/controllers/config/$(arg hand_type)/$(arg side)/trajectory_controller.yaml"/>
 
   <node if="$(arg start_control)" name="controller_timed_launch" pkg="sr_utilities_common" type="timed_roslaunch.sh"
-        args="$(arg controller_start_delay) dx_launch $(arg control_mode)_controller.launch hand_type:=$(arg hand_type) side:=$(arg side) output:=$(arg controller_output)" />
+        args="$(arg controller_start_delay) dx_launch $(arg control_mode)_controller.launch output:=$(arg controller_output)" />
   
   <node pkg="dx_robot" type="check_subdevices_to_enable_robot" name="check_subdevices_to_enable_robot" output="screen" />
 </launch>


### PR DESCRIPTION
## Proposed changes

In order for control modes to be switched while a driver is running, the relevant controller config must be loaded into the param server. The old implementation required a control mode to be specified on driver launch upon which the relevant controller config would be loaded, however no other controller configs were loaded, leading to controller switching not being possible.

This fix loads all configs in the dexee real launch file in a similar manner to how we load them in dx_host https://github.com/shadow-robot/dx_host/blob/noetic-devel/dx_robot/launch/start_dexee.launch#L48-L53.

While in dx_host the configs are loaded in the `start_dexee` launch file, I felt moving them to the "real" launch file was more clear.

## Types of changes

What types of changes does your code introduce?

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

Put an x in the boxes that apply. You can also fill these out after creating the PR. This is a reminder of what we should look for before merging this code. I have:

- [x] Read and follow the [contributing guidelines](https://github.com/shadow-robot/sr_documentation/blob/master/CONTRIBUTING.md).
- [x] Checked that all tests pass with my changes
- [ ] Added tests (automatic or manual) that prove the fix is effective or that the feature works
- [ ] Added necessary documentation (if appropriate)
- [x] Added the corresponding license to each file and add the current year of any one that you modified.
- [x] Tested on real hardware (if appropriate)
